### PR TITLE
Add RSS auto-discovery link to HTML head

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,6 +14,28 @@ import BackToTop from "@components/BackToTop.astro";
     <div class="flex items-center justify-between">
       <div>&copy; {new Date().getFullYear()} • {SITE.AUTHOR} </div>
       <div class="flex flex-wrap items-center gap-1.5">
+        <a
+          href="/rss.xml"
+          aria-label="RSS Feed"
+          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-black group-focus-visible:animate-pulse group-focus-visible:stroke-black dark:group-hover:stroke-white dark:group-focus-visible:stroke-white"
+          >
+            <path d="M4 11a9 9 0 0 1 9 9"></path>
+            <path d="M4 4a16 16 0 0 1 16 16"></path>
+            <circle cx="5" cy="19" r="1" fill="currentColor" stroke="none"></circle>
+          </svg>
+        </a>
         <button
           id="light-theme-button"
           aria-label="Light theme"

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -68,6 +68,9 @@ const { title, description, image = "/astro-micro.jpg" } = Astro.props;
 <link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
 <script is:inline src="/pagefind/pagefind-ui.js"></script>
 
+<!-- RSS Auto-Discovery -->
+<link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/rss.xml" />
+
 <!-- Mastodon -->
 <link rel="me" href="https://hachyderm.io/@oscb"/>
 


### PR DESCRIPTION
The RSS feed was implemented at /rss.xml but missing the <link rel="alternate">
tag in Head.astro, so browsers and feed readers couldn't auto-detect it.

https://claude.ai/code/session_0176mebe8AszbU3SP1kGAcRi