### PR TITLE
Apply Catppuccin Latte/Mocha color theme

### DIFF
--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -14,13 +14,10 @@ if (type === "info") {
 
 const baseClasses = "relative my-4 flex rounded border p-3";
 const typeClasses = {
-  default:
-    "border-orange-800 bg-orange-100 text-orange-950 dark:border-orange-200/20 dark:bg-orange-950/20 dark:text-orange-200",
-  info: "border-blue-800 bg-blue-100 text-blue-950 dark:border-blue-200/20 dark:bg-blue-950/20 dark:text-blue-200",
-  warning:
-    "border-yellow-800 bg-yellow-100 text-yellow-950 dark:border-yellow-200/20 dark:bg-yellow-950/20 dark:text-yellow-200",
-  error:
-    "border-red-800 bg-red-100 text-red-950 dark:border-red-200/20 dark:bg-red-950/20 dark:text-red-200",
+  default: "border-ctp-peach bg-ctp-peach/10 text-ctp-text",
+  info: "border-ctp-blue bg-ctp-blue/10 text-ctp-text",
+  warning: "border-ctp-yellow bg-ctp-yellow/10 text-ctp-text",
+  error: "border-ctp-red bg-ctp-red/10 text-ctp-text",
 };
 ---
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ import BackToTop from "@components/BackToTop.astro";
         <a
           href="/rss.xml"
           aria-label="RSS Feed"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-9 items-center justify-center rounded-sm border border-ctp-surface0 hover:bg-ctp-surface1 focus-visible:bg-ctp-surface1"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -29,7 +29,7 @@ import BackToTop from "@components/BackToTop.astro";
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-black group-focus-visible:animate-pulse group-focus-visible:stroke-black dark:group-hover:stroke-white dark:group-focus-visible:stroke-white"
+            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-ctp-mauve group-focus-visible:animate-pulse group-focus-visible:stroke-ctp-mauve"
           >
             <path d="M4 11a9 9 0 0 1 9 9"></path>
             <path d="M4 4a16 16 0 0 1 16 16"></path>
@@ -39,7 +39,7 @@ import BackToTop from "@components/BackToTop.astro";
         <button
           id="light-theme-button"
           aria-label="Light theme"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-9 items-center justify-center rounded-sm border border-ctp-surface0 hover:bg-ctp-surface1 focus-visible:bg-ctp-surface1"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -51,7 +51,7 @@ import BackToTop from "@components/BackToTop.astro";
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-black group-focus-visible:animate-pulse group-focus-visible:stroke-black dark:group-hover:stroke-white dark:group-focus-visible:stroke-white"
+            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-ctp-mauve group-focus-visible:animate-pulse group-focus-visible:stroke-ctp-mauve"
           >
             <circle cx="12" cy="12" r="5"></circle>
             <line x1="12" y1="1" x2="12" y2="3"></line>
@@ -67,7 +67,7 @@ import BackToTop from "@components/BackToTop.astro";
         <button
           id="dark-theme-button"
           aria-label="Dark theme"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-9 items-center justify-center rounded-sm border border-ctp-surface0 hover:bg-ctp-surface1 focus-visible:bg-ctp-surface1"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -79,7 +79,7 @@ import BackToTop from "@components/BackToTop.astro";
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-black group-focus-visible:animate-pulse group-focus-visible:stroke-black dark:group-hover:stroke-white dark:group-focus-visible:stroke-white"
+            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-ctp-mauve group-focus-visible:animate-pulse group-focus-visible:stroke-ctp-mauve"
           >
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
           </svg>
@@ -87,7 +87,7 @@ import BackToTop from "@components/BackToTop.astro";
         <button
           id="system-theme-button"
           aria-label="System theme"
-          class="group flex size-9 items-center justify-center rounded-sm border border-black/15 hover:bg-black/5 focus-visible:bg-black/5 dark:border-white/20 dark:hover:bg-white/5 dark:focus-visible:bg-white/5"
+          class="group flex size-9 items-center justify-center rounded-sm border border-ctp-surface0 hover:bg-ctp-surface1 focus-visible:bg-ctp-surface1"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -99,7 +99,7 @@ import BackToTop from "@components/BackToTop.astro";
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-black group-focus-visible:animate-pulse group-focus-visible:stroke-black dark:group-hover:stroke-white dark:group-focus-visible:stroke-white"
+            class="transition-colors duration-300 ease-in-out group-hover:animate-pulse group-hover:stroke-ctp-mauve group-focus-visible:animate-pulse group-focus-visible:stroke-ctp-mauve"
           >
             <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
             <line x1="8" y1="21" x2="16" y2="21"></line>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -28,7 +28,7 @@ import { SITE } from "@consts";
         <button
           id="magnifying-glass"
           aria-label="Search"
-          class="flex items-center rounded-sm border border-black/15 bg-neutral-100 px-2 py-1 text-xs transition-colors duration-300 ease-in-out hover:bg-black/5 hover:text-black focus-visible:bg-black/5 focus-visible:text-black dark:border-white/20 dark:bg-neutral-900 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:bg-white/5 dark:focus-visible:text-white"
+          class="flex items-center rounded-sm border border-ctp-surface0 bg-ctp-base px-2 py-1 text-xs transition-colors duration-300 ease-in-out hover:bg-ctp-surface1 hover:text-ctp-mauve focus-visible:bg-ctp-surface1 focus-visible:text-ctp-mauve"
         >
           <svg
             height="16"

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -21,7 +21,7 @@ const {
   href={href}
   target={external ? "_blank" : "_self"}
   class={cn(
-    "inline-block decoration-black/30 dark:decoration-white/30 hover:decoration-black/50 focus-visible:decoration-black/50 dark:hover:decoration-white/50 dark:focus-visible:decoration-white/50 text-current hover:text-black focus-visible:text-black dark:hover:text-white dark:focus-visible:text-white transition-colors duration-300 ease-in-out",
+    "inline-block decoration-ctp-overlay0 hover:decoration-ctp-mauve focus-visible:decoration-ctp-mauve text-current hover:text-ctp-mauve focus-visible:text-ctp-mauve transition-colors duration-300 ease-in-out",
     underline && "underline underline-offset-[3px]",
     group && "group"
   )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,11 +4,98 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Catppuccin Latte (light mode) */
+:root {
+  --ctp-rosewater: #dc8a78;
+  --ctp-flamingo: #dd7878;
+  --ctp-pink: #ea76cb;
+  --ctp-mauve: #8839ef;
+  --ctp-red: #d20f39;
+  --ctp-maroon: #e64553;
+  --ctp-peach: #fe640b;
+  --ctp-yellow: #df8e1d;
+  --ctp-green: #40a02b;
+  --ctp-teal: #179299;
+  --ctp-sky: #04a5e5;
+  --ctp-sapphire: #209fb5;
+  --ctp-blue: #1e66f5;
+  --ctp-lavender: #7287fd;
+  --ctp-text: #4c4f69;
+  --ctp-subtext1: #5c5f77;
+  --ctp-subtext0: #6c6f85;
+  --ctp-overlay2: #7c7f93;
+  --ctp-overlay1: #8c8fa1;
+  --ctp-overlay0: #9ca0b0;
+  --ctp-surface2: #acb0be;
+  --ctp-surface1: #bcc0cc;
+  --ctp-surface0: #ccd0da;
+  --ctp-base: #eff1f5;
+  --ctp-mantle: #e6e9ef;
+  --ctp-crust: #dce0e8;
+}
+
+/* Catppuccin Mocha (dark mode) */
+.dark {
+  --ctp-rosewater: #f5e0dc;
+  --ctp-flamingo: #f2cdcd;
+  --ctp-pink: #f5c2e7;
+  --ctp-mauve: #cba6f7;
+  --ctp-red: #f38ba8;
+  --ctp-maroon: #eba0ac;
+  --ctp-peach: #fab387;
+  --ctp-yellow: #f9e2af;
+  --ctp-green: #a6e3a1;
+  --ctp-teal: #94e2d5;
+  --ctp-sky: #89dceb;
+  --ctp-sapphire: #74c7ec;
+  --ctp-blue: #89b4fa;
+  --ctp-lavender: #b4befe;
+  --ctp-text: #cdd6f4;
+  --ctp-subtext1: #bac2de;
+  --ctp-subtext0: #a6adc8;
+  --ctp-overlay2: #9399b2;
+  --ctp-overlay1: #7f849c;
+  --ctp-overlay0: #6c7086;
+  --ctp-surface2: #585b70;
+  --ctp-surface1: #45475a;
+  --ctp-surface0: #313244;
+  --ctp-base: #1e1e2e;
+  --ctp-mantle: #181825;
+  --ctp-crust: #11111b;
+}
+
 @theme {
   --font-sans: Geist Sans, ui-sans-serif, system-ui, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-mono: Geist Mono, ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, 'Liberation Mono', 'Courier New', monospace;
+
+  --color-ctp-rosewater: var(--ctp-rosewater);
+  --color-ctp-flamingo: var(--ctp-flamingo);
+  --color-ctp-pink: var(--ctp-pink);
+  --color-ctp-mauve: var(--ctp-mauve);
+  --color-ctp-red: var(--ctp-red);
+  --color-ctp-maroon: var(--ctp-maroon);
+  --color-ctp-peach: var(--ctp-peach);
+  --color-ctp-yellow: var(--ctp-yellow);
+  --color-ctp-green: var(--ctp-green);
+  --color-ctp-teal: var(--ctp-teal);
+  --color-ctp-sky: var(--ctp-sky);
+  --color-ctp-sapphire: var(--ctp-sapphire);
+  --color-ctp-blue: var(--ctp-blue);
+  --color-ctp-lavender: var(--ctp-lavender);
+  --color-ctp-text: var(--ctp-text);
+  --color-ctp-subtext1: var(--ctp-subtext1);
+  --color-ctp-subtext0: var(--ctp-subtext0);
+  --color-ctp-overlay2: var(--ctp-overlay2);
+  --color-ctp-overlay1: var(--ctp-overlay1);
+  --color-ctp-overlay0: var(--ctp-overlay0);
+  --color-ctp-surface2: var(--ctp-surface2);
+  --color-ctp-surface1: var(--ctp-surface1);
+  --color-ctp-surface0: var(--ctp-surface0);
+  --color-ctp-base: var(--ctp-base);
+  --color-ctp-mantle: var(--ctp-mantle);
+  --color-ctp-crust: var(--ctp-crust);
 }
 
 /*
@@ -48,13 +135,13 @@
   body {
     @apply font-sans antialiased;
     @apply flex flex-col;
-    @apply bg-neutral-100 dark:bg-neutral-900;
-    @apply text-black/75 dark:text-white/75;
+    @apply bg-ctp-base;
+    @apply text-ctp-text;
   }
 
   header {
     @apply fixed left-0 right-0 top-0 z-50 py-6;
-    @apply bg-neutral-100/75 dark:bg-neutral-900/75;
+    @apply bg-ctp-base/75;
     @apply saturate-200 backdrop-blur-xs;
   }
 
@@ -69,19 +156,19 @@
   article {
     @apply prose prose-neutral max-w-full dark:prose-invert prose-img:mx-auto prose-img:my-auto;
     @apply prose-headings:font-semibold;
-    @apply prose-headings:text-black dark:prose-headings:text-white;
+    @apply prose-headings:text-ctp-text;
   }
 }
 
 @layer utilities {
   article a {
     @apply font-sans text-current underline underline-offset-[3px];
-    @apply decoration-black/30 dark:decoration-white/30;
+    @apply decoration-ctp-overlay0;
     @apply transition-colors duration-300 ease-in-out;
   }
   article a:hover {
-    @apply text-black dark:text-white;
-    @apply decoration-black/50 dark:decoration-white/50;
+    @apply text-ctp-mauve;
+    @apply decoration-ctp-mauve;
   }
 }
 
@@ -104,44 +191,44 @@ html.scrolled #back-to-top {
 
 /* shiki config */
 pre {
-  @apply border border-black/15 py-5 dark:border-white/20;
+  @apply border border-ctp-surface0 py-5;
 }
 
 :root {
-  --astro-code-foreground: #09090b;
-  --astro-code-background: #fafafa;
-  --astro-code-token-comment: #a19595;
-  --astro-code-token-keyword: #f47067;
-  --astro-code-token-string: #00a99a;
-  --astro-code-token-function: #429996;
-  --astro-code-token-constant: #2b70c5;
-  --astro-code-token-parameter: #4e8fdf;
-  --astro-code-token-string-expression: #ae42a0;
-  --astro-code-token-punctuation: #8996a3;
-  --astro-code-token-link: #8d85ff;
+  --astro-code-foreground: #4c4f69;
+  --astro-code-background: #e6e9ef;
+  --astro-code-token-comment: #9ca0b0;
+  --astro-code-token-keyword: #8839ef;
+  --astro-code-token-string: #40a02b;
+  --astro-code-token-function: #1e66f5;
+  --astro-code-token-constant: #fe640b;
+  --astro-code-token-parameter: #d20f39;
+  --astro-code-token-string-expression: #ea76cb;
+  --astro-code-token-punctuation: #8c8fa1;
+  --astro-code-token-link: #04a5e5;
 }
 
 .dark {
-  --astro-code-foreground: #fafafa;
-  --astro-code-background: #09090b;
-  --astro-code-token-comment: #a19595;
-  --astro-code-token-keyword: #f47067;
-  --astro-code-token-string: #00a99a;
-  --astro-code-token-function: #6eafad;
-  --astro-code-token-constant: #b3cceb;
-  --astro-code-token-parameter: #4e8fdf;
-  --astro-code-token-string-expression: #bf7db6;
-  --astro-code-token-punctuation: #8996a3;
-  --astro-code-token-link: #8d85ff;
+  --astro-code-foreground: #cdd6f4;
+  --astro-code-background: #181825;
+  --astro-code-token-comment: #6c7086;
+  --astro-code-token-keyword: #cba6f7;
+  --astro-code-token-string: #a6e3a1;
+  --astro-code-token-function: #89b4fa;
+  --astro-code-token-constant: #fab387;
+  --astro-code-token-parameter: #f38ba8;
+  --astro-code-token-string-expression: #f5c2e7;
+  --astro-code-token-punctuation: #bac2de;
+  --astro-code-token-link: #89dceb;
 }
 
 /* copy code button on codeblocks */
 .copy-code {
-  @apply absolute right-3 top-3 grid size-9 place-content-center rounded-sm border border-black/15 bg-neutral-100 text-center duration-300 ease-in-out dark:border-white/20 dark:bg-neutral-900;
+  @apply absolute right-3 top-3 grid size-9 place-content-center rounded-sm border border-ctp-surface0 bg-ctp-base text-center duration-300 ease-in-out;
 }
 
 .copy-code:hover {
-  @apply bg-[#E9E9E9] transition-colors dark:bg-[#232323];
+  @apply bg-ctp-surface0 transition-colors;
 }
 
 .copy-code:active {


### PR DESCRIPTION
Replaces the minimal black/white/neutral palette with Catppuccin:
- Latte for light mode, Mocha for dark mode
- Defines all palette CSS variables in :root and .dark
- Registers colors as Tailwind utilities via @theme (bg-ctp-*, text-ctp-*, etc.)
- Updates body, header, article, links, buttons, callouts, and copy-code button
- Updates Shiki syntax highlighting to official Catppuccin token colors
- Uses mauve as the primary accent color for links and interactive hover states

https://claude.ai/code/session_01NFjhbRtknXdUgksTsMTfeA