### PR TITLE
Apply Catppuccin Latte/Mocha color theme

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,8 +141,8 @@
 
   header {
     @apply fixed left-0 right-0 top-0 z-50 py-6;
-    @apply bg-ctp-base/75;
-    @apply saturate-200 backdrop-blur-xs;
+    @apply bg-ctp-base/90;
+    @apply backdrop-blur-sm;
   }
 
   main {


### PR DESCRIPTION
## Summary

- Adds full Catppuccin Latte (light) and Mocha (dark) palette as CSS custom properties, registered as Tailwind utilities (`bg-ctp-*`, `text-ctp-*`, etc.)
- Updates body, header, article, links, buttons, callouts, and copy-code button to use Catppuccin colors — no more `dark:` variant duplication since CSS vars swap automatically
- Updates Shiki syntax highlighting to official Catppuccin token colors
- Uses **mauve** as the primary accent for links and interactive hover states
- Fixes header backdrop: removes `saturate-200` (was causing the header to look lighter than the body) and adjusts opacity/blur for a clean frosted glass effect

## Test plan

- [ ] Check light mode (Latte) — background, text, links, nav, footer buttons
- [ ] Check dark mode (Mocha) — same elements
- [ ] Verify header blends correctly with body as you scroll
- [ ] Check callout boxes (default/info/warning/error) in both modes
- [ ] Check syntax highlighting in a blog post with code blocks
- [ ] Check hover/focus states on links and buttons

https://claude.ai/code/session_01NFjhbRtknXdUgksTsMTfeA